### PR TITLE
Add example with hidden fields

### DIFF
--- a/bundles/core/src/main/webapp/app-root/components/ui.granite/showhide-select.json
+++ b/bundles/core/src/main/webapp/app-root/components/ui.granite/showhide-select.json
@@ -73,6 +73,11 @@
                   "name": "./mytextfield1b",
                   "fieldLabel": "Example textfield 1b",
                   "fieldDescription": "Visible for Option 1."
+                },
+                "myhiddenfield": {
+                  "sling:resourceType": "granite/ui/components/coral/foundation/form/hidden",
+                  "name": "./myhiddenfield",
+                  "value": "option1"
                 }
               }
             },
@@ -90,6 +95,11 @@
                   "required": true,
                   "fieldLabel": "Example path field",
                   "fieldDescription": "Visible for Option 2."
+                },
+                "myhiddenfield": {
+                  "sling:resourceType": "granite/ui/components/coral/foundation/form/hidden",
+                  "name": "./myhiddenfield",
+                  "value": "option2"
                 }
               }
             },
@@ -117,6 +127,11 @@
                   "name": "./mycheckbox3",
                   "text": "Checkbox 3",
                   "fieldDescription": "Visible for Option 3."
+                },
+                "myhiddenfield": {
+                  "sling:resourceType": "granite/ui/components/coral/foundation/form/hidden",
+                  "name": "./myhiddenfield",
+                  "value": "option3"
                 }
               }
             }


### PR DESCRIPTION
To test fix https://github.com/wcm-io/io.wcm.wcm.ui.granite/pull/59

hidden fields are added to "Show/Hide Select" component in http://localhost:4502/editor.html/content/wcmio-graniteui-sample-app/en/showhide.html